### PR TITLE
Suggestion on demographic line

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ The Code for America community expects that Code for America network activities 
 6. Encourage members and participants to listen as much as they speak.
 7. Strive to build tools that are open and free technology for public use. Activities that aim to foster public use, not 8. private gain, are prioritized.
 9. Prioritize access for and input from those who are traditionally excluded from the civic process.
-10. Work to ensure that all demographics present in the community are represented.
+10. Work to ensure that the community is well-represented in the planning, design and implementation of civic tech. This includes encouraging participation from women, minorities and traditionally marginalized group. 
 11. Actively involve community groups and those with subject matter expertise in the decision-making process.
 12. Ensure that the relationships and conversations between community members, the local government staff and community partners remain respectful, participatory, and productive.
-13. Provide an environment where people are not subjected to discrimination or harassment.
+13. Provide an environment where people are free from discrimination or harassment.
 
 Code for America reserves the right to ask anyone in violation of these policies not to participate in Code for America events or network activities.
 


### PR DESCRIPTION
If we're sticking to the "use plain language" tenet of Gov.uk's styleguide I think "demographic" is too marketing of a term for "types of humans". To me it feels less inclusive simply because it's a bit of a jargon word. Being really explicit about which humans you're talking about and then leaving this as an open doc means there's room to add and evolve. Thanks for the offer to participate!
