### PR TITLE
Additional verbiage and some reorganization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,34 +13,28 @@ The Code for America community expects that Code for America network activities 
 6. Encourage members and participants to listen as much as they speak.
 7. Strive to build tools that are open and free technology for public use. Activities that aim to foster public use, not private gain, are prioritized.
 8. Prioritize access for and input from those who are traditionally excluded from the civic process.
-9. Work to ensure that the community is well-represented in the planning, design, and implementation of civic tech. This includes encouraging participation from women, minorities, and traditionally marginalized groups. 
+9. Work to ensure that the community is well-represented in the planning, design, and implementation of civic tech. This includes encouraging participation from women, minorities, and traditionally marginalized groups.
 10. Actively involve community groups and those with subject matter expertise in the decision-making process.
 11. Ensure that the relationships and conversations between community members, the local government staff and community partners remain respectful, participatory, and productive.
 12. Provide an environment where people are free from discrimination or harassment.
 
-Code for America reserves the right to ask anyone in violation of these policies not to participate in Code for America events or network activities.
+Code for America reserves the right to bar anyone in violation of these policies from participation in Code for America events or network activities.
 
 ####Code for America's Anti-Harassment Policy
 
-This anti-harassment policy is based on <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">the example policy</a> from the Geek Feminism wiki, created by the Ada Initiative and other volunteers.
-
-This policy is based on several other policies, including the Ohio LinuxFest anti-harassment policy, written by Esther Filderman and Beth Lynn Eicher, and the Con Anti-Harassment Project. Mary Gardiner, Valerie Aurora, Sarah Smith, and Donna Benjamin generalized the policies and added supporting material. Many members of LinuxChix, Geek Feminism and other groups contributed to this work.
-
-* * * 
-
-All Code for America events and their staff, presenters, and participants are held to an anti-harassment policy, included below.
+All Code for America events and their staff, presenters, and participants are held to an anti-harassment policy, included below. We expect participants to follow this code of conduct at all Code for America network activities and social events.
 
 In addition to governing our own events by this policy, Code for America will only lend our brand and fund groups that offer an anti-harassment policy to their attendees. For information on how to offer an anti-harassment policy to your group, <a href="https://docs.google.com/a/codeforamerica.org/document/d/1Zg2FDt7awgfCmdcbzMwKHMb1A7KDOhs_z7ibCb3TLLQ/edit">see this guide</a>.
 
 Code for America is dedicated to providing a harassment-free experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. We do not tolerate harassment of staff, presenters, and participants in any form. Sexual language and imagery is not appropriate for any Code for America event or network activity, including talks. Anyone in violation of these policies may expelled from Code for America events or network activities, at the discretion of the event organizers.
 
-Harassment includes but is not limited to: offensive verbal or written comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion; sexual images in public spaces; deliberate intimidation; stalking; following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; unwelcome sexual attention; unwarranted exclusion; and patronizing language or action.
+Harassment includes but is not limited to: offensive verbal or written comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion; sexual images in public spaces; deliberate intimidation; stalking; following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; unwelcome sexual attention; unwarranted exclusion; and patronizing language or action. As a general rule, Yes means yes; no means no; and maybe means no. You are encouraged to ask for unequivocal consent for all activities during the conference; this includes touching other people (e.g., hands on shoulders, hugs, etc).
 
-If a participant engages in harassing behavior, the event organizers may take any action they deem appropriate, including warning the offender or expulsion from Code for America events and network activities. 
+If a participant engages in harassing behavior, the event organizers may take any action they deem appropriate, including warning the offender, expulsion or sanctioning from future Code for America events and network activities, Participants asked to stop any harassing behavior are expected to comply immediately.
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the event staff immediately. You can contact them at [EVENT ORGANIZER EMAIL AND PHONE NUMBER]. Event staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event.
 
-If you cannot reach an event organizer and/or it is an emergency, please call 911 and/or remove yourself from the situation. 
+If you cannot reach an event organizer and/or it is an emergency, please call 911 and/or remove yourself from the situation.
 
 You can also contact Code for America about harassment at safespace@codeforamerica.org and feel free to use the email template below. Code for America staff acknowledge that we are not always in a position to evaluate a given situation due to the number of events and the fact that our team is not always present. However, we are hopeful that by providing these guidelines we are establishing a community that jointly adheres to these values and can provide an environment that is welcoming to all.
 
@@ -50,7 +44,13 @@ We value your attendance and hope that by communicating these expectations widel
 
 SUBJECT: Safe Space alert at [EVENT NAME]
 
-I am writing because of harassment at a Code for America Communities event, (NAME, PLACE, DATE OF EVENT). 
+I am writing because of harassment at a Code for America Communities event, (NAME, PLACE, DATE OF EVENT).
 
 You can reach me at (CONTACT INFO). Thank you.
+
+####Acknowledgements
+
+This anti-harassment policy is based on <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">the example policy</a> from the Geek Feminism wiki, created by the Ada Initiative and other volunteers.
+
+This policy is based on several other policies, including the Ohio LinuxFest anti-harassment policy, written by Esther Filderman and Beth Lynn Eicher, and the Con Anti-Harassment Project. Mary Gardiner, Valerie Aurora, Sarah Smith, and Donna Benjamin generalized the policies and added supporting material. Many members of LinuxChix, Geek Feminism and other groups contributed to this work.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ As a general rule, "yes" means **yes**; "no" means **no**; and "maybe" means **n
 
 If a participant engages in harassing behavior, the event organizers may take any action they deem appropriate, including warning the offender, expulsion or sanctioning from future Code for America events and network activities. Participants asked to stop any harassing behavior are expected to comply immediately.
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the event staff immediately. You can contact them at [EVENT ORGANIZER EMAIL AND PHONE NUMBER]. Event staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event.
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the event staff immediately. You can contact them at `[EVENT ORGANIZER EMAIL AND PHONE NUMBER]`. Event staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event.
 
 If you cannot reach an event organizer and/or it is an emergency, please call 911 and/or remove yourself from the situation.
 
@@ -44,11 +44,13 @@ We value your attendance and hope that by communicating these expectations widel
 
 ####Email Template for Anti-Harassment Reporting
 
-SUBJECT: Safe Space alert at [EVENT NAME]
+SUBJECT: Safe Space alert at `[EVENT NAME]`
 
-I am writing because of harassment at a Code for America Communities event, (NAME, PLACE, DATE OF EVENT).
+I am writing because of harassment at a Code for America Communities event, `[NAME, PLACE, DATE OF EVENT]`.
 
-You can reach me at (CONTACT INFO). Thank you.
+`[DESCRIBE THE VIOLATION: WHAT, WHERE, WHEN, HOW, WHO]`
+
+You can reach me at `[CONTACT INFO]`. Thank you.
 
 ####Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -22,21 +22,23 @@ Code for America reserves the right to bar anyone in violation of these policies
 
 ####Code for America's Anti-Harassment Policy
 
-All Code for America events and their staff, presenters, and participants are held to an anti-harassment policy, included below. We expect participants to follow this code of conduct at all Code for America network activities and social events.
+All Code for America events and their staff, presenters, and participants are held to this anti-harassment policy. We expect participants to follow this code of conduct at all Code for America network activities and social events.
 
 In addition to governing our own events by this policy, Code for America will only lend our brand and fund groups that offer an anti-harassment policy to their attendees. For information on how to offer an anti-harassment policy to your group, <a href="https://docs.google.com/a/codeforamerica.org/document/d/1Zg2FDt7awgfCmdcbzMwKHMb1A7KDOhs_z7ibCb3TLLQ/edit">see this guide</a>.
 
 Code for America is dedicated to providing a harassment-free experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. We do not tolerate harassment of staff, presenters, and participants in any form. Sexual language and imagery is not appropriate for any Code for America event or network activity, including talks. Anyone in violation of these policies may expelled from Code for America events or network activities, at the discretion of the event organizers.
 
-Harassment includes but is not limited to: offensive verbal or written comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion; sexual images in public spaces; deliberate intimidation; stalking; following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; unwelcome sexual attention; unwarranted exclusion; and patronizing language or action. As a general rule, Yes means yes; no means no; and maybe means no. You are encouraged to ask for unequivocal consent for all activities during the conference; this includes touching other people (e.g., hands on shoulders, hugs, etc).
+Harassment includes but is not limited to: offensive verbal or written comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion; sexual images in public spaces; deliberate intimidation; stalking; following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; unwelcome sexual attention; unwarranted exclusion; and patronizing language or action.
 
-If a participant engages in harassing behavior, the event organizers may take any action they deem appropriate, including warning the offender, expulsion or sanctioning from future Code for America events and network activities, Participants asked to stop any harassing behavior are expected to comply immediately.
+As a general rule, Yes means yes; no means no; and maybe means no. You are encouraged to ask for unequivocal consent for all activities during the conference; this includes touching other people (e.g., hands on shoulders, hugs, etc).
+
+If a participant engages in harassing behavior, the event organizers may take any action they deem appropriate, including warning the offender, expulsion or sanctioning from future Code for America events and network activities. Participants asked to stop any harassing behavior are expected to comply immediately.
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the event staff immediately. You can contact them at [EVENT ORGANIZER EMAIL AND PHONE NUMBER]. Event staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event.
 
 If you cannot reach an event organizer and/or it is an emergency, please call 911 and/or remove yourself from the situation.
 
-You can also contact Code for America about harassment at safespace@codeforamerica.org and feel free to use the email template below. Code for America staff acknowledge that we are not always in a position to evaluate a given situation due to the number of events and the fact that our team is not always present. However, we are hopeful that by providing these guidelines we are establishing a community that jointly adheres to these values and can provide an environment that is welcoming to all.
+You can also contact Code for America about harassment at safespace@codeforamerica.org using the email template below. Code for America staff acknowledge that we are not always in a position to evaluate a given situation due to the number of events and the fact that our team is not always present. However, we are hopeful that by providing these guidelines we are establishing a community that jointly adheres to these values and can provide an environment that is welcoming to all.
 
 We value your attendance and hope that by communicating these expectations widely we can all enjoy a harassment-free environment.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Code for America is dedicated to providing a harassment-free experience for ever
 
 Harassment includes but is not limited to: offensive verbal or written comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion; sexual images in public spaces; deliberate intimidation; stalking; following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; unwelcome sexual attention; unwarranted exclusion; and patronizing language or action.
 
-As a general rule, Yes means yes; no means no; and maybe means no. You are encouraged to ask for unequivocal consent for all activities during the conference; this includes touching other people (e.g., hands on shoulders, hugs, etc).
+As a general rule, "yes" means **yes**; "no" means **no**; and "maybe" means **no**. You are encouraged to ask for unequivocal consent for all activities during the conference; this includes touching other people (e.g., hands on shoulders, hugs, etc).
 
 If a participant engages in harassing behavior, the event organizers may take any action they deem appropriate, including warning the offender, expulsion or sanctioning from future Code for America events and network activities. Participants asked to stop any harassing behavior are expected to comply immediately.
 


### PR DESCRIPTION
The acknowledgements were distracting where they were; that's why I moved them to the end. Explicitly stating "no means no" bears repeating.
