### PR TITLE
Add a Spanish version of the Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,48 @@
-codeofconduct
-=============
+# Code of Conduct / Código de Conducta
 
-#### Code for America's Code of Conduct
+- [In English](#code-4-puerto-rico-code-of-conduct)
+  - [How to Contribute](#how-to-contribute-to-this-code-of-conduct)
+  - [More information and incident reports](#more-information-and-incident-reports)
+- [En español](#código-de-conducta-de-code-4-puerto-rico)
+  - [Cómo contribuir](#cómo-contribuir-a-este-código-de-conducta)
+  - [Más Información o reportar incidentes](#más-información-o-reporte-de-incidentes)
 
-The Code for America community expects that Code for America network activities, events, and digital forums:
+## Code for America Code of Conduct
 
-1. Are a safe and respectful environment for all participants.
-2. Are a place where people are free to fully express their identities.
-3. Presume the value of others. Everyone’s ideas, skills, and contributions have value.
-4. Don’t assume everyone has the same context, and encourage questions.
-5. Find a way for people to be productive with their skills (technical and not) and energy. Use language such as “yes/and”, not “no/but.”
-6. Encourage members and participants to listen as much as they speak.
-7. Strive to build tools that are open and free technology for public use. Activities that aim to foster public use, not private gain, are prioritized.
-8. Prioritize access for and input from those who are traditionally excluded from the civic process.
-9. Work to ensure that the community is well-represented in the planning, design, and implementation of civic tech. This includes encouraging participation from women, minorities, and traditionally marginalized groups. 
-10. Actively involve community groups and those with subject matter expertise in the decision-making process.
-11. Ensure that the relationships and conversations between community members, the local government staff and community partners remain respectful, participatory, and productive.
-12. Provide an environment where people are free from discrimination or harassment.
+In Code for America we believe that everybody should feel comfortable, accepted, and safe.
 
-Code for America reserves the right to ask anyone in violation of these policies not to participate in Code for America network activities, events, and digital forums.
+For this reason our Code of Conduct is very important and guides all interactions in our event and properties. PLease take some time to read our [english version](code-of-conduct-en.md).
 
-#### Code for America's Anti-Harassment Policy
+### How to contribute to this code of conduct
 
-This anti-harassment policy is based on <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">the example policy</a> from the Geek Feminism wiki, created by the Ada Initiative and other volunteers.
+Our code of conduct is a living document that our community can help change and evolve. There's a couple of ways you can do this:
 
-This policy is based on several other policies, including the Ohio LinuxFest anti-harassment policy, written by Esther Filderman and Beth Lynn Eicher, and the Con Anti-Harassment Project. Mary Gardiner, Valerie Aurora, Sarah Smith, and Donna Benjamin generalized the policies and added supporting material. Many members of LinuxChix, Geek Feminism and other groups contributed to this work.
+1. You can create an Issue with your comments and suggestions.
+2. You can create a Pull Request to suggest your changes directly.
 
-* * * 
+We await your contributions :heart:
 
-All Code for America network activities, events, and digital forums and their staff, presenters, and participants are held to an anti-harassment policy, included below.
+### More information and incident reports
 
-In addition to governing our own events by this policy, Code for America will only lend our brand and fund groups that offer an anti-harassment policy to their attendees. For information on how to offer an anti-harassment policy to your group, <a href="https://docs.google.com/a/codeforamerica.org/document/d/1Zg2FDt7awgfCmdcbzMwKHMb1A7KDOhs_z7ibCb3TLLQ/edit">see this guide</a>.
+If you hace any questions or want to report a violation to our code of conduct please contact **safespace** at **codeforamerica.org**.
 
-Code for America is dedicated to providing a harassment-free experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. We do not tolerate harassment of staff, presenters, and participants in any form. Sexual language and imagery is not appropriate for any Code for America event or network activity, including talks. Anyone in violation of these policies may be expelled from Code for America network activities, events, and digital forums, at the discretion of the event organizer or forum administrator.
+----
 
-Harassment includes but is not limited to: offensive verbal or written comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion; sexual images in public spaces; deliberate intimidation; stalking; following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; unwelcome sexual attention; unwarranted exclusion; and patronizing language or action.
+## Código de Conducta de Code 4 Puerto Rico
 
-If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from Code for America network activities, events, and digital forums. 
+En Code for America creemos que todxs deben sentirse cómodos, aceptados y seguros.
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the event staff or forum administrator immediately. You can contact them at [EVENT ORGANIZER/FORUM ADMINISTRATOR EMAIL AND PHONE NUMBER]. Event staff or forum administrators will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event.
+Por esta razón nuestro código de conducta de Code for America tiene mucha importancía y guia toda interacción en nuestros eventos y propiedades. Por favor tome un momento para leer la [versión en español](code-of-conduct-es.md).
 
-If you cannot reach an event organizer or forum administrator and/or it is an emergency, please call 911 and/or remove yourself from the situation. 
+### Cómo contribuir a este código de conducta
 
-You can also contact Code for America about harassment by emailing **safespace** at **codeforamerica.org** and feel free to use the email template below. Code for America staff acknowledge that we are not always in a position to evaluate a given situation due to the number of events and the fact that our team is not always present. However, we are hopeful that by providing these guidelines we are establishing a community that jointly adheres to these values and can provide an environment that is welcoming to all.
+Nuestro código de conducta es un documento viviente que nuestra comunidad puede ayudar a cambiar y evolucionar. Puedes hacer esto de varias maneras:
 
-We value your attendance and hope that by communicating these expectations widely we can all enjoy a harassment-free environment.
+1. Puedes abrir un Issue con tus comentarios y/o sugerencias.
+2. Puedes someter un Pull Request para sugerir cambios a los documentos en este repositorio.
 
-#### Email Template for Anti-Harassment Reporting
+Esperamos sus contribuciones :heart:
 
-SUBJECT: Safe Space alert at [EVENT NAME]
+### Más información o reporte de incidentes
 
-I am writing because of harassment at a Code for America Communities event, (NAME, PLACE, DATE OF EVENT). 
-
-You can reach me at (CONTACT INFO). Thank you.
-
+Si tienes alguna pregunta o quieres reportar una violación a nuestro código de conducta por favor contacte **safespace** at **codeforamerica.org**.

--- a/code-of-conduct-en.md
+++ b/code-of-conduct-en.md
@@ -1,0 +1,55 @@
+# Code of Conduct
+
+## Code for America's Code of Conduct
+
+The Code for America community expects that Code for America network activities, events, and digital forums:
+
+1. Are a safe and respectful environment for all participants.
+2. Are a place where people are free to fully express their identities.
+3. Presume the value of others. Everyone’s ideas, skills, and contributions have value.
+4. Don’t assume everyone has the same context, and encourage questions.
+5. Find a way for people to be productive with their skills (technical and not) and energy. Use language such as “yes/and”, not “no/but.”
+6. Encourage members and participants to listen as much as they speak.
+7. Strive to build tools that are open and free technology for public use. Activities that aim to foster public use, not private gain, are prioritized.
+8. Prioritize access for and input from those who are traditionally excluded from the civic process.
+9. Work to ensure that the community is well-represented in the planning, design, and implementation of civic tech. This includes encouraging participation from women, minorities, and traditionally marginalized groups.
+10. Actively involve community groups and those with subject matter expertise in the decision-making process.
+11. Ensure that the relationships and conversations between community members, the local government staff and community partners remain respectful, participatory, and productive.
+12. Provide an environment where people are free from discrimination or harassment.
+
+Code for America reserves the right to ask anyone in violation of these policies not to participate in Code for America network activities, events, and digital forums.
+
+## Code for America's Anti-Harassment Policy
+
+This anti-harassment policy is based on <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">the example policy</a> from the Geek Feminism wiki, created by the Ada Initiative and other volunteers.
+
+This policy is based on several other policies, including the Ohio LinuxFest anti-harassment policy, written by Esther Filderman and Beth Lynn Eicher, and the Con Anti-Harassment Project. Mary Gardiner, Valerie Aurora, Sarah Smith, and Donna Benjamin generalized the policies and added supporting material. Many members of LinuxChix, Geek Feminism and other groups contributed to this work.
+
+----
+
+All Code for America network activities, events, and digital forums and their staff, presenters, and participants are held to an anti-harassment policy, included below.
+
+In addition to governing our own events by this policy, Code for America will only lend our brand and fund groups that offer an anti-harassment policy to their attendees. For information on how to offer an anti-harassment policy to your group, <a href="https://docs.google.com/a/codeforamerica.org/document/d/1Zg2FDt7awgfCmdcbzMwKHMb1A7KDOhs_z7ibCb3TLLQ/edit">see this guide</a>.
+
+Code for America is dedicated to providing a harassment-free experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. We do not tolerate harassment of staff, presenters, and participants in any form. Sexual language and imagery is not appropriate for any Code for America event or network activity, including talks. Anyone in violation of these policies may be expelled from Code for America network activities, events, and digital forums, at the discretion of the event organizer or forum administrator.
+
+Harassment includes but is not limited to: offensive verbal or written comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion; sexual images in public spaces; deliberate intimidation; stalking; following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; unwelcome sexual attention; unwarranted exclusion; and patronizing language or action.
+
+If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from Code for America network activities, events, and digital forums.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the event staff or forum administrator immediately. You can contact them at [EVENT ORGANIZER/FORUM ADMINISTRATOR EMAIL AND PHONE NUMBER]. Event staff or forum administrators will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event.
+
+If you cannot reach an event organizer or forum administrator and/or it is an emergency, please call 911 and/or remove yourself from the situation.
+
+You can also contact Code for America about harassment by emailing **safespace** at **codeforamerica.org** and feel free to use the email template below. Code for America staff acknowledge that we are not always in a position to evaluate a given situation due to the number of events and the fact that our team is not always present. However, we are hopeful that by providing these guidelines we are establishing a community that jointly adheres to these values and can provide an environment that is welcoming to all.
+
+We value your attendance and hope that by communicating these expectations widely we can all enjoy a harassment-free environment.
+
+## Email Template for Anti-Harassment Reporting
+
+SUBJECT: Safe Space alert at [EVENT NAME]
+
+I am writing because of harassment at a Code for America Communities event, (NAME, PLACE, DATE OF EVENT).
+
+You can reach me at (CONTACT INFO). Thank you.
+

--- a/code-of-conduct-es.md
+++ b/code-of-conduct-es.md
@@ -1,0 +1,53 @@
+# Código de Conducta
+
+La comunidad de "Code for America" espera que las actividades y eventos de "Code for America":
+
+1. Sean un ambiente seguro y de respeto para todos los participantes.
+2. Sean un lugar donde puedan expresar sus identidades libremente.
+3. Asume el valor de otros. Las ideas, habilidades y contribuciones de todos tienen valor.
+4. Que no se asuma que todos los participantes tienen o entienden el mismo contexto y se promueva discusión y preguntas.
+5. Que se encuentre alguna manera para que la persona sea productiva usando sus destrezas, sean estas técnicas o no, y con su energía. Se recomienda utilizar lenguaje positivo.
+6. Que se promueva a sus miembros a escuchar al igual que hablan.
+7. Afanarse a crear herramientas que son abiertas y libres para uso público. Se le dará prioridad a actividades que promuevan el uso público de estas herramientas y tecnologías; no de ganancia privada.
+8. Se le dará prioridad de acceso y aportación a personas que tradicionalmente están excluidas del proceso cívico.
+9. Asegurar que toda la comunidad esté representada en la planificación, diseño y la implementación de cualquier tecnología cívica. Esto incluye la participación de mujeres, minorías y grupos que tradicionalmente han sido marginados.
+10. Activamente involucrar grupos comunitarios y aquellos que tienen experiencia en el tema y en el proceso de toma de decisiones.
+11. Asegurar que las conversaciones entre los miembros de la comunidad, funcionarios de gobierno y amigos de la comunidad sean respetuosas, productivas y participativas.
+12. Proveer un ambiente libre de discriminación y hostigamiento.
+
+"Code for America" se reserva el derecho de pedirle a cualquier persona que no participe de sus actividades si ha violentado alguna de estas reglas.
+
+## Política Anti Acoso de "Code for America"
+
+Esta política esta basada en [este ejemplo](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) encontrado en el Wiki de "Geek Feminism" creado por el "Ada Initiative" y otros voluntarios.
+
+Esta política está basada en otras similares como por ejemplo la
+"Ohio LinuxFest anti-harassment policy" - by Esther Filderman and Beth Lynn Eicher, and the "Con Anti-Harassment Project". La generalización de la política y el material de apoyo fue generado por Mary Gardiner, Valerie Aurora, Sarah Smith y Donna Benjamin. En adición un sin numero de miembros de "LinuxChix", "Geek Feminism" y otros grupos han contribuido a esta política.
+
+----
+
+Todo el personal, presentador y participante de eventos de "Code for America" está sujeto a la política anti-hostigamiento que está a continuación.
+
+Además de aplicarle ésta política a los eventos de "Code for America", "Code for America" le prestará su marca y dará fondos a grupos que le ofrezcan a sus miembros una política anti-hostigamiento parecida a sus participantes. Para mas información de cómo lograr esto [favor ver esta guía.](https://docs.google.com/a/codeforamerica.org/document/d/1Zg2FDt7awgfCmdcbzMwKHMb1A7KDOhs_z7ibCb3TLLQ/edit)
+
+"Code for America" está comprometida con proveer una experiencia sin hostigamiento para todos sin importar su género, identidad y expresión de género, orientación sexual, incapacidad física, apariencia física, tamaño corporal, etnia, edad o religión. No se tolera acoso de ninguna índole hacia los organizadores, presentadores o participantes. Lenguaje y/o imágenes de índole sexual no son apropiadas para ningún evento, presentación o actividad de "Code for America". Cualquier persona que violente estas políticas será expulsado, a discreción de los organizadores, del evento o actividad de "Code for America".
+
+Hostigamiento incluye pero no se limita a: comentarios ofensivos, tanto verbales o escritos, referente a género, identidad o expresión de género, orientación sexual, incapacidad física, apariencia física, tamaño corporal, etnia, religión; imágenes sexuales en espacios públicos; intimidación deliberada; acecho; grabación o fotografía acosante; interrupción o sabotaje constante de eventos o presentaciones; contacto físico inapropiado; atención sexual no deseado; exclusión injustificada; y acciones o lenguaje despectivo.
+
+Si algún participante se comporta de alguna manera no aceptable, los organizadores tienen la libertad de tomar la acción que les parezca apropiada. Esto incluye la advertencia por el comportamiento o la expulsión de actividades o eventos de "Code for America".
+
+Si estas recibiendo o te sientes acosado, te percatas que alguien esta siendo acosado o tienes cualquier otra preocupación, por favor contacte algún miembro del comité organizador del evento inmediatamente. Puedes utilizar [TELÉFONO Y CORREO ELECTRÓNICO DEL ORGANIZADOR(A)]. Los miembros del comité organizador están disponibles para ayudar a cualquier participante, a llamar seguridad del local del evento o hasta llamar a la policía local si se amerita. También están dispuestos a escoltar y asistir al participante que se siente acosado a sentirse seguro durante la duración del evento.
+
+De no poder conseguir a los organizadores y es una emergencia por favor contacte al 911, o al número de emergencias de su localidad, y/o remuévase de la situación hasta que llegue ayuda o se sienta seguro.
+
+También puede contactar a "Code for America" sobre alguna situación de acoso en particular utilizando la cuenta de correo electrónico que es **safespace** at **codeforamerica.org**. Puede utilizar la siguiente plantilla para enviar su correo electrónico. Los miembros de "Code for America" no siempre pueden o están en la posición para evaluar todas las situaciones debido a la cantidad de eventos que se celebran y el hecho que los miembros no siempre están presentes. No obstante esperamos que al proveer esta guía de comportamiento estamos estableciendo una comunidad que se adhiere a estos valores y pueda proveer un ambiente agradable e inclusivo para todos.
+
+Valoramos su presencia y esperamos que al comunicar estas expectativas todos podamos disfrutar de un ambiente libre de acoso.
+
+## Borrador para Reportar Acoso
+
+TEMA: Safe Space alert at [NOMBRE DEL EVENTO]
+
+Estoy escribiendo para reportar una situación de acoso en un evento comunitario de "Code for America", (NOMBRE, LUGAR, FECHA DEL EVENTO).
+
+Me pueden contactar en (INFORMACIÓN DE CONTACTO). Gracias.


### PR DESCRIPTION
Hello there 👋🏼 

I've added a Spanish version of the Code of Conduct along with some supporting changes to make the repo simpler to navigate.

- Added code-of-conduct-es.md: this is the main Spanish translation
- Added code-of-conduct-en.md: this is the new home for the English version of the CoC
- Refactored the README.md to help navigate to the language versions of the CoC
  - Refactor includes versions of the text in English and Spanish.

Why refactor the README? The main reason is that long READMEs often go unread and may be intimidatting to new users. It also helps to be friendly right of the bat. The different links point to the language version but also give pointers on how people can contribute to them.

I hope you all find this useful and look forward to feedback. ❤️ 🇵🇷 